### PR TITLE
invite fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## [1.1.2] - 2025-05-09
+### Fixes
+- Display name changes in the admin bot log
+- Limited invite to once use
+- Limited `/invite` to only Roles with _Create Invite_ Permission
+
 ## [1.1.1] - 2025-03-15
 ### Fixes
 - EffectiveName to Name in new_joiner table

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.feiyu.discord</groupId>
 	<artifactId>sg-tavern</artifactId>
-	<version>1.1.1</version>
+	<version>1.1.2</version>
 	<name>sg-tavern</name>
 
 	<properties>

--- a/src/main/java/com/feiyu/discord/sg/tavern/commands/InviteLinkCommand.java
+++ b/src/main/java/com/feiyu/discord/sg/tavern/commands/InviteLinkCommand.java
@@ -28,10 +28,11 @@ public class InviteLinkCommand extends ListenerAdapter {
             Member member = event.getMember();
             Guild guild = event.getGuild();
             TextChannel landingChannel = guild.getTextChannelById(valuesConfig.getRulesChannelId());
-            log.info("InviteLinkCommand.invitelink by : {}", member.getEffectiveName());
+            log.info("InviteLinkCommand.invitelink by : {}", member.getUser().getName());
             
             Invite invite = landingChannel.createInvite()
                     .setMaxAge(2L, TimeUnit.DAYS)
+                    .setMaxUses(1)
                     .setUnique(true)
                     .complete();
             

--- a/src/main/java/com/feiyu/discord/sg/tavern/services/CommandService.java
+++ b/src/main/java/com/feiyu/discord/sg/tavern/services/CommandService.java
@@ -6,13 +6,10 @@ import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
-
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -35,7 +32,7 @@ public class CommandService {
         
         // general commands
         guild.upsertCommand("invite", "Get an invite link to this server (valid 48hrs)")
-                .setDefaultPermissions(DefaultMemberPermissions.ENABLED)
+                .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.CREATE_INSTANT_INVITE))
                 .queue();
         
         log.info("Finish insert commands");


### PR DESCRIPTION
1. Display name changes in the admin bot log
2. Limited invite to once use
3. Limited `/invite` to only Roles with _Create Invite_ Permission